### PR TITLE
Joint developer worksation fixes

### DIFF
--- a/start-dds-server-tunnel.example.bat
+++ b/start-dds-server-tunnel.example.bat
@@ -4,7 +4,7 @@ Rem This is an example bat file that can be used to start the dds tunnel on the 
 
 echo Please run the following in your dev environment, then press any key to continue. You should then see a continuous stream of heartbeat messages in 10 seconds.
 echo ===========================================
-echo python3 ./rti/dds-tunnel/start-tunnel.py --domain_id 31 client --server_address 129.97.185.187:7400
+echo python3 ./dds-tunnel/start-tunnel.py --domain_id 31 client --server_address 129.97.185.187:7400
 echo ===========================================
 
 pause

--- a/start-tunnel.py
+++ b/start-tunnel.py
@@ -18,7 +18,7 @@ def environment_or_default(env_var_name, posix_default, nt_default):
     raise Exception(f"Unknown os {os.name}")
 
 
-NDDS_HOME = environment_or_default('NDDS_HOME', '/opt/rti_connext_dds-6.0.1', 'C:\\Program Files\\rti_connext_dds-6.0.1')
+NDDS_HOME = environment_or_default('NDDSHOME', '/opt/rti_connext_dds-6.0.1', 'C:\\Program Files\\rti_connext_dds-6.0.1')
 ROUTING_SERVICE_EXEC = environment_or_default('ROUTING_SERVICE_EXEC', os.path.join(NDDS_HOME, 'bin/rtiroutingservice'), os.path.join(NDDS_HOME, 'bin\\rtiroutingservice.bat'))
 if os.name == 'posix':
     INT_SIGNAL = signal.SIGINT


### PR DESCRIPTION
- Update `NDDS_HOME` environment variable to `NDDSHOME`.
- Change the path that is displayed to users to run the `start-tunnel.py` script.